### PR TITLE
Fix Dockerfile and rewrite main.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /var/cxplayground
 
 COPY --from=build /build/examples /var/cxplayground/examples
 COPY --from=build /build/cxplayground /var/cxplayground/cxplayground
+COPY dist /var/cxplayground/dist
 
 EXPOSE 5336
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 
@@ -12,30 +11,20 @@ import (
 )
 
 func main() {
-	host := ":5336"
-
-	mux := http.NewServeMux()
 	workingDir, _ := os.Getwd()
 	if err := playground.InitPlayground(workingDir); err != nil {
 		// error captured while initiating the playground examples, should be handled in the future
 		fmt.Println("Fail to initiating palyground examples")
 	}
 
-	mux.HandleFunc("/playground/examples", playground.GetExampleFileList)
-	mux.HandleFunc("/playground/examples/code", playground.GetExampleFileContent)
+	http.HandleFunc("/playground/examples", playground.GetExampleFileList)
+	http.HandleFunc("/playground/examples/code", playground.GetExampleFileContent)
 
-	mux.Handle("/", http.FileServer(http.Dir("./dist")))
-	mux.Handle("/program/", webapi.NewAPI("/program", actions.AST))
-	mux.HandleFunc("/eval", playground.RunProgram)
+	http.Handle("/", http.FileServer(http.Dir("./dist")))
+	http.Handle("/program/", webapi.NewAPI("/program", actions.AST))
+	http.HandleFunc("/eval", playground.RunProgram)
 
-	listener, err := net.Listen("tcp", host)
-	if err != nil {
-		fmt.Printf("Listener error: %v", err)
-	}
 	fmt.Println("Starting web service for CX playground on http://127.0.0.1:5336/")
 
-	err = http.Serve(listener, mux)
-	if err != nil {
-		fmt.Printf("Service error: %v", err)
-	}
+	http.ListenAndServe(":5336", nil)
 }


### PR DESCRIPTION
This commit fixes the Dockerfile. Previously the web assets in `dist`
were not copied over to the docker image and consequently the webserver
would return a 404 on "/".

Rewrote the main.go to use the default mux and use http.ListenAndServe
for simplicity.