### PR TITLE
Initialize types.Allocator to fix concatenating-strings.cx problem

### DIFF
--- a/playground/playground.go
+++ b/playground/playground.go
@@ -22,6 +22,9 @@ import (
 	cxinit "github.com/skycoin/cx/cx/init"
 	cxparsingcompletor "github.com/skycoin/cx/cxparser/cxparsingcompletor"
 	cxpartialparsing "github.com/skycoin/cx/cxparser/cxpartialparsing"
+
+	"github.com/skycoin/cx/cx/types"
+	cxast "github.com/skycoin/cx/cx/ast"
 )
 
 var (
@@ -35,6 +38,8 @@ type ExampleContent struct {
 }
 
 var InitPlayground = func(workingDir string) error {
+	types.Allocator = cxast.AllocateSeq
+	
 	examplesDir = filepath.Join(workingDir, "./examples")
 	exampleCollection = make(map[string]string)
 


### PR DESCRIPTION
Fixed crashing problem when running concatenating-strings.cx on cx-playground.
The reason: 
In concatenating-strings.cx, there is call part "str.concate".
To push "Hello" and "Bye" to new memory, Allocator is called.
But Allocator is not initialized.
In cx repo, cmd/cx/main.go, Run() function, 
it is initialized with "types.Allocator = ast.AllocateSeq"

So I followed as this.